### PR TITLE
Name representation is now an object

### DIFF
--- a/DGC.Core.Types.schema.json
+++ b/DGC.Core.Types.schema.json
@@ -26,9 +26,9 @@
       "maxLength": 50
     },
     "person_name": {
-      "description": "Person name: Surname(s), forename(s) - in that order",
+      "description": "Person name: Surname(s), given name(s) - in that order",
       "required": [
-        "_fn", "_gn"
+        "fnt", "gnt"
       ],
       "type": "object",
       "properties": {
@@ -41,7 +41,7 @@
             "Červenková Panklová"
           ]
         },
-        "_fn": {
+        "fnt": {
           "title": "Standardised family name",
           "description": "The family name(s) of the person transliterated",
           "type": "string",
@@ -59,7 +59,7 @@
             "Jiřina Alena"
           ]
         },
-        "_gn": {
+        "gnt": {
           "title": "Standardised given name",
           "description": "The given name(s) of the person transliterated",
           "type": "string",

--- a/DGC.schema.json
+++ b/DGC.schema.json
@@ -11,12 +11,8 @@
   "type": "object",
   "properties": {
     "nam": {
-      "description": "Surname(s), forename(s) - in that order",
-      "type": "array",
-      "entry": {
-        "$ref": "https://ec.europa.eu/dgc/DGC.Core.Types.schema.json#/$defs/person_name"
-      },
-      "minNam": 1
+      "description": "Surname(s), given name(s) - in that order",
+      "$ref": "https://ec.europa.eu/dgc/DGC.Core.Types.schema.json#/$defs/person_name"
     },
     "dob": {
       "description": "Date of Birth, ISO 8601",


### PR DESCRIPTION
Fixed so that the nam-element is now an object with fn, fnt, gn, gnt.
Previously it was an array with one element, the person_name.

For those generating code from the schema I also changed _fn to fnt and _gn to gnt.