### PR TITLE
Fix for representation of dob

### DIFF
--- a/DGC.Core.Types.schema.json
+++ b/DGC.Core.Types.schema.json
@@ -4,11 +4,6 @@
   "title": "EU DGC",
   "description": "EU Digital Green Certificate Core Data Types",
   "$defs": {
-    "dob_valid_date_range": {
-      "description": "Date type ISO 8601 - date part only, restricted to range 1900-2099",
-      "type": "string",
-      "pattern": "[19|20][0-9][0-9]-(0[1-9]|1[0-2])-([0-2][1-9]|3[0|1])"
-    },
     "dose_posint": {
       "description": "Dose Number / Total doses in Series: positive integer, range: [1,9]",
       "type": "integer",

--- a/DGC.schema.json
+++ b/DGC.schema.json
@@ -15,8 +15,11 @@
       "$ref": "https://ec.europa.eu/dgc/DGC.Core.Types.schema.json#/$defs/person_name"
     },
     "dob": {
-      "description": "Date of Birth, ISO 8601",
-      "$ref": "https://ec.europa.eu/dgc/DGC.Core.Types.schema.json#/$defs/dob_valid_date_range"
+      "title": "Date of birth",
+      "description": "Date of Birth of the person addressed in the DGC. ISO 8601 date format",
+      "type": "string",
+      "format": "date",
+      "example": "1979-04-14"
     },
     "dsc": {
       "description": "Document Signing Certificate: 8 bytes",

--- a/DGC.schema.json
+++ b/DGC.schema.json
@@ -16,9 +16,10 @@
     },
     "dob": {
       "title": "Date of birth",
-      "description": "Date of Birth of the person addressed in the DGC. ISO 8601 date format",
+      "description": "Date of Birth of the person addressed in the DGC. ISO 8601 date format restricted to range 1900-2099",
       "type": "string",
       "format": "date",
+      "pattern": "[19|20][0-9][0-9]-(0[1-9]|1[0-2])-([0-2][1-9]|3[0|1])",
       "example": "1979-04-14"
     },
     "dsc": {


### PR DESCRIPTION
The original did not specify the format as "date" but instead used a pattern.