### PR TITLE
Alignment of the schema to final version of the EU regulation

### DIFF
--- a/DGC.Types.schema.json
+++ b/DGC.Types.schema.json
@@ -98,11 +98,6 @@
           "type": "string",
           "format": "date-time"
         },
-        "dr": {
-          "description": "Date/Time of Test Result",
-          "type": "string",
-          "format": "date-time"
-        },
         "tr": {
           "description": "Test Result",
           "$ref": "https://id.uvci.eu/DGC.ValueSets.schema.json#/$defs/test-result"
@@ -143,7 +138,7 @@
           "$ref": "https://id.uvci.eu/DGC.ValueSets.schema.json#/$defs/disease-agent-targeted"
         },
         "fr": {
-          "description": "ISO 8601 Date of First Positive Test Result",
+          "description": "ISO 8601 Date of First Positive NAA Test Result",
           "type": "string",
           "format": "date"
         },

--- a/DGC.combined-schema.json
+++ b/DGC.combined-schema.json
@@ -222,11 +222,6 @@
           "type": "string",
           "format": "date-time"
         },
-        "dr": {
-          "description": "Date/Time of Test Result",
-          "type": "string",
-          "format": "date-time"
-        },
         "tr": {
           "description": "Test Result",
           "$ref": "#/$defs/test-result"
@@ -267,7 +262,7 @@
           "$ref": "#/$defs/disease-agent-targeted"
         },
         "fr": {
-          "description": "ISO 8601 Date of First Positive Test Result",
+          "description": "ISO 8601 Date of First Positive NAA Test Result",
           "type": "string",
           "format": "date"
         },

--- a/examples/test-naa.json
+++ b/examples/test-naa.json
@@ -14,7 +14,6 @@
       "nm": "Roche LightCycler qPCR",
       "tr": "260415000",
       "sc": "2021-04-13T14:20:00+00:00",
-      "dr": "2021-04-13T20:00:01+00:00",
       "tc": "GGD Fryslân, L-Heliconweg",
       "co": "NL",
       "is": "Ministry of Public Health, Welfare and Sport",

--- a/examples/test-rat.json
+++ b/examples/test-rat.json
@@ -14,7 +14,6 @@
       "tr": "260415000",
       "ma": "1232",
       "sc": "2021-04-13T14:20:00+00:00",
-      "dr": "2021-04-13T14:40:01+00:00",
       "tc": "GGD Fryslân, L-Heliconweg",
       "co": "NL",
       "is": "Ministry of Public Health, Welfare and Sport",


### PR DESCRIPTION
Test result date has been removed from the data set in the recent version of the regulation.
Recovery certificate is based only on the NAA test result.