### PR TITLE
Update to release 1.2.0 for dropping field test/dr

### DIFF
--- a/DGC.combined-schema.json
+++ b/DGC.combined-schema.json
@@ -3,7 +3,7 @@
   "$id": "https://id.uvci.eu/DGC.combined-schema.json",
   "title": "EU DGC",
   "description": "EU Digital Green Certificate",
-  "$comment": "Schema version 1.1.0",
+  "$comment": "Schema version 1.2.0",
   "required": [
     "ver",
     "nam",
@@ -17,7 +17,7 @@
       "type": "string",
       "pattern": "^\\d+.\\d+.\\d+$",
       "examples": [
-        "1.1.0"
+        "1.2.0"
       ]
     },
     "nam": {

--- a/DGC.schema.json
+++ b/DGC.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://id.uvci.eu/DGC.schema.json",
   "title": "EU DGC",
   "description": "EU Digital Green Certificate",
-  "$comment": "Schema version 1.1.0",
+  "$comment": "Schema version 1.2.0",
   "required": [
     "ver",
     "nam",
@@ -17,7 +17,7 @@
       "type": "string",
       "pattern": "^\\d+.\\d+.\\d+$",
       "examples": [
-        "1.1.0"
+        "1.2.0"
       ]
     },
     "nam": {

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This repository contains a JSON schema for the EU Digital Green Certificate.
 
-**Schema version:** 1.1.0
-**Release date:** 2020-05-26
+**Schema version:** 1.2.0
+**Release date:** 2020-05-27
 
 
 ## Introduction


### PR DESCRIPTION
Test result date has been removed from the data set in the recent version of the regulation.
Recovery certificate is based only on the NAA test result.