### PR TITLE
test-manf.json no cumulative update?

### DIFF
--- a/valuesets/test-manf.json
+++ b/valuesets/test-manf.json
@@ -2,6 +2,20 @@
   "valueSetId": "covid-19-lab-test-manufacturer-and-name",
   "valueSetDate": "2021-05-27",
   "valueSetValues": {
+    "1242": {
+      "display": "Bionote, Inc, NowCheck COVID-19 Ag Test",
+      "lang": "en",
+      "active": false,
+      "system": "https://covid-19-diagnostics.jrc.ec.europa.eu/devices",
+      "version": "2021-04-22 02:23:55 CET"
+    },
+    "1065": {
+      "display": "Becton Dickinson, Veritor System Rapid Detection of SARS-CoV-2",
+      "lang": "en",
+      "active": false,
+      "system": "https://covid-19-diagnostics.jrc.ec.europa.eu/devices",
+      "version": "2021-04-22 02:23:55 CET"
+    },
     "1833": {
       "display": "AAZ-LMB, COVID-VIRO",
       "lang": "en",


### PR DESCRIPTION
More than a real PR this is an input for discussion with diff.

From an implementer's perspective I wouldn't have expected two test manufacturers to disappear "overnight" with a valueset update.

Example: If I got tested with 1242 or 1065 yesterday, shouldn't it be validatable today?

I think this is especially important for the business rules, e.g. here:

https://github.com/ehn-digital-green-development/dgc-business-rules


Regarding the ValueSets in general I've got some more questions:

- What's the function of the "active" flag in the valuesets and why don't you use it?

- How will valuesets be versioned? Globally vs on valueset level (-> valueSetDate = version?) vs  on entry level?

- Will there be one official API Endpoint to get updated valueset data?

- How is the offline use of DCC systems addressed, is this a design goal?

TIA

Miguel

